### PR TITLE
Revert debug settings in DevContainer workflow

### DIFF
--- a/.github/workflows/devcontainer-build-images.yml
+++ b/.github/workflows/devcontainer-build-images.yml
@@ -7,10 +7,8 @@ on:
   push:
     branches:
       - main
-      - create-devcontainer
-    # テストのため一時的にコメントアウト
-    # paths:
-    #   - '.devcontainer/**'
+    paths:
+      - '.devcontainer/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
Refs #1

## Summary

デバッグ用に追加していた設定を本番用に戻す。

## Changes

- `create-devcontainer`ブランチをトリガーから削除
- `.devcontainer/**`のpathsフィルタを再有効化

🤖 Generated with [Claude Code](https://claude.com/claude-code)