### PR TITLE
fix: CODEX_VERSION 未設定 & upload-sarif 二次エラーを修正

### DIFF
--- a/.github/workflows/devcontainer-build-images.yml
+++ b/.github/workflows/devcontainer-build-images.yml
@@ -78,6 +78,7 @@ jobs:
             OSV_SCANNER_VERSION=${{ steps.versions.outputs.osv_scanner_version }}
             GOSEC_VERSION=${{ steps.versions.outputs.gosec_version }}
             NEXTJS_VERSION=${{ steps.versions.outputs.nextjs_version }}
+            CODEX_VERSION=${{ steps.versions.outputs.codex_version }}
 
       - name: Security scan
         uses: aquasecurity/trivy-action@0.35.0
@@ -87,7 +88,6 @@ jobs:
           output: trivy-results.sarif
 
       - uses: github/codeql-action/upload-sarif@v4
-        if: always()
         with:
           sarif_file: trivy-results.sarif
           category: devcontainer-${{ matrix.image }}


### PR DESCRIPTION
## Summary

- `CODEX_VERSION` を build-args に追加（`TFLINT_AWS_PLUGIN_VERSION` と同種のバグ）
- `upload-sarif` の `if: always()` を削除し、ビルド失敗時の二次エラーを解消

Closes #26

## Test plan

- [x] `workflow_dispatch` で手動実行し、local ビルドで Codex がバージョン固定でインストールされることを確認
- [x] ビルド失敗時に `Path does not exist: trivy-results.sarif` エラーが出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)