### PR TITLE
ローカル用のClaude Codeをlatest運用に

### DIFF
--- a/.github/workflows/devcontainer-pr-validation.yml
+++ b/.github/workflows/devcontainer-pr-validation.yml
@@ -57,7 +57,6 @@ jobs:
         run: |
           docker run --rm ${{ matrix.image }}:test bash -c "
             set -e
-            claude --version
             node --version
             npm --version
             git --version
@@ -66,6 +65,15 @@ jobs:
             aws --version
             delta --version
             zsh --version
+          "
+
+      - name: Verify local tools
+        if: matrix.target == 'local'
+        run: |
+          docker run --rm ${{ matrix.image }}:test bash -c "
+            set -e
+            claude --version
+            codex --version
           "
 
       - name: Verify infrastructure tools

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -272,6 +272,7 @@ RUN npm install -g next@${NEXTJS_VERSION} react@${REACT_VERSION} react-dom@${REA
 RUN mkdir -p /home/node/.codex
 
 # Claude Code — バージョン固定すると公式プラグインマーケットプレイスのスキーマ非互換等の問題が発生するため、Latest運用とする
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl -fsSL https://claude.ai/install.sh | bash
 ENV DISABLE_AUTOUPDATER=1
 


### PR DESCRIPTION
# Summary

- ローカル用のClaude Codeをlatest運用に

# Detail

- ローカル用のClaude Codeをバージョン固定すると、公式プラグインの利用に支障が生じた
- ローカル開発用ClaudeCodeのバージョン固定はもともとあまりメリットがなかった。かえって開発効率を損なっていると判断し、例外的にLatest運用とする